### PR TITLE
Add missing TEB functions

### DIFF
--- a/Source/Include/KNSoft/NDK/NT/Extension/Runtime.h
+++ b/Source/Include/KNSoft/NDK/NT/Extension/Runtime.h
@@ -6,8 +6,21 @@
 
 #pragma region TEB Fast Access (Without Pointer Reference)
 
-#if !defined(_WIN64)
-
+__forceinline
+UCHAR
+NtReadCurrentTebByte(unsigned int Offset) {
+    return *(PUCHAR)((PBYTE)NtCurrentTeb() + Offset);
+}
+__forceinline
+USHORT
+NtReadCurrentTebUshort(unsigned int Offset) {
+    return *(PUSHORT)((PBYTE)NtCurrentTeb() + Offset);
+}
+__forceinline
+ULONG
+NtReadCurrentTebUlong(unsigned int Offset) {
+    return *(PULONG)((PBYTE)NtCurrentTeb() + Offset);
+}
 __forceinline
 unsigned __int64
 NtReadCurrentTebUlonglong(
@@ -19,8 +32,6 @@ NtReadCurrentTebUlonglong(
     li.HighPart = NtReadCurrentTebUlong(Offset + sizeof(ULONG));
     return li.QuadPart;
 }
-
-#endif
 
 #ifdef FIELD_TYPE
 #define NtReadTeb(m) ((FIELD_TYPE(TEB, m))(\


### PR DESCRIPTION
For me, SlimDetours compiles with warnings about undefined functions without this change, and the demo doesn't compile at all. I know that it compiles in GitHub pages, not sure why, perhaps it has additional MSVC components.

I'm also not sure if adding these functions here will cause a conflict in case they're available. Perhaps we could use different names for them.